### PR TITLE
Proposal: Allow the use of image alt as caption when title is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ const processor = remark().use([[images, options]]);
 | `elasticContainer`    | `true`                 | Insert elastic container to avoid layout jumps when the image loads                       |
 | `blurredBackground`   | `true`                 | Add a blurred background while the image is loading                                       |
 | `processCaption`      | `(caption) => caption` | Define a function to process image caption, eg. convert markdown to HTML                  |
+| `altAsFallbackCaption`| `false`                | Use the image `alt` attribute as a caption when there is no `title` attribute             |
 
 #### Process Caption
 

--- a/src/DEFAULT_OPTIONS.js
+++ b/src/DEFAULT_OPTIONS.js
@@ -10,7 +10,8 @@ const DEFAULT_OPTIONS = {
   loadingPolicy: 'eager',
   elasticContainer: true,
   blurredBackground: true,
-  processCaption: (caption) => caption
+  processCaption: (caption) => caption,
+  altAsFallbackCaption: false,
 };
 
 export default DEFAULT_OPTIONS;

--- a/src/render.js
+++ b/src/render.js
@@ -109,9 +109,9 @@ export function renderFigure({ node, sources, options, bgImage, bgData }) {
       )
     : undefined;
 
-  const captionTag = node.title
+  const captionTag = (node.title || (node.alt && options.altAsFallbackCaption))
     ? renderCaption({
-        caption: node.title,
+        caption: node.title || node.alt,
         className: options.figCaptionClassName,
         processCaption: options.processCaption
       })


### PR DESCRIPTION
HI again :wave: 

This pull request adds the `altAsFallbackCaption` option, which defaults to `false`.

When set to `true`, the image `alt` attribute will be used as a caption when there is no `title` attribute present.

Why? Well, because while this is correct:

```md
![I am the alt](image.png "i am the title")
```

There's a ton of markdown content out there like this:

```md
![I should be the alt, but I'm really the title](image.png)
```

This pull request would (optionally) allow people to fall back to the alt if no title attribute is present.

Thanks for considering it :slightly_smiling_face: 
