### PR TITLE
fix: Strip out empty srcSet entries passed to renderFigure()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ function responsiveImages(pluginOptions) {
       images.forEach(({ node, sources, inLink, bgImage, bgData }) => {
         const rawHtml = renderFigure({
           node,
-          sources,
+          sources: sources.filter(src => src.srcSet.length > 0),
           inLink,
           bgImage,
           bgData,


### PR DESCRIPTION
Some of my images where not showing up, so I did some digging and
noticed that an array like this was passed to `renderFigure()`:

```js
[
  { aspectRatio: 0, srcSet: [], width: 1000 },
  { aspectRatio: 0, srcSet: [], width: 2000 },
  {
    aspectRatio: 1.4970059880239521,
    srcSet: [ [Object], [Object] ],
    width: 250
  },
  { aspectRatio: 1.5015015015015014, srcSet: [ [Object] ], width: 500 }
]
```

In `renderFigure()` we use `srcSets.shift().srcSet` which in a case like
this means the img tag will be skipped.

This filters the sources list to only those that have an actual srcSet
value. The array passed to `renderFigure()` becomes:

```js
[
  {
    aspectRatio: 1.4970059880239521,
    srcSet: [ [Object], [Object] ],
    width: 250
  },
  { aspectRatio: 1.5015015015015014, srcSet: [ [Object] ], width: 500 }
]
```