### PR TITLE
chore: Added repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   },
   "author": "Florian Eckerstofer <florian@eckerstorfer.net>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/florianeckerstorfer/remark-images.git"
+  },
   "keywords": [
     "remark",
     "responsive",


### PR DESCRIPTION
Every time I'm on the NPM page for this package, I'm looking for the
link to the repo. But it's not there because it's not set in the
package.json file.

This fixes that.