### PR TITLE
Add callback that processes target file name

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -86,7 +86,7 @@ describe('remark-images', () => {
     expect(result('img').attr('alt')).toBe('My image');
   });
 
-  it.only('should use result processTargetFileName() option for file name', async () => {
+  it('should use result processTargetFileName() option for file name', async () => {
     const processTargetFileName = (targetFile, data) =>
       targetFile.replace(data.search, data.replace);
     const thisProcessor = remark()

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -85,4 +85,26 @@ describe('remark-images', () => {
     expect(result('img').attr('src')).toBe('foo.gif');
     expect(result('img').attr('alt')).toBe('My image');
   });
+
+  it.only('should use result processTargetFileName() option for file name', async () => {
+    const processTargetFileName = (targetFile, data) =>
+      targetFile.replace(data.search, data.replace);
+    const thisProcessor = remark()
+      .use(html, { sanitize: false })
+      .use([[plugin, { ...options, processTargetFileName }]]);
+
+    const input = '![My image](foo.jpg)';
+
+    const output = await thisProcessor
+      .data({ search: 'foo', replace: 'bar' })
+      .process(input);
+    const result = cheerio.load(String(output));
+    expect(result('figure').length).toBe(1);
+    expect(result('picture').length).toBe(1);
+    expect(result('source').length).toBe(2);
+    expect(result('img').length).toBe(1);
+    expect(result('img').attr('src')).toContain('bar-320.jpg');
+    expect(result('img').attr('alt')).toBe('My image');
+    expect(result('figcaption').length).toBe(0);
+  });
 });

--- a/__tests__/srcSetHelpers.spec.js
+++ b/__tests__/srcSetHelpers.spec.js
@@ -11,8 +11,12 @@ const srcDir = 'site';
 const fileName = 'foo.jpg';
 const width = 320;
 const resolutions = [1, 2];
+const data = {};
 
 describe('getSrcSet()', () => {
+  const processTargetFileName = jest.fn();
+  processTargetFileName.mockImplementation(targetFile => targetFile);
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -24,7 +28,7 @@ describe('getSrcSet()', () => {
   });
 
   it('should return src set for multiple resolutions', async () => {
-    const srcSet = await getSrcSet({ srcDir, fileName, width, resolutions });
+    const srcSet = await getSrcSet({ srcDir, fileName, width, resolutions, data, processTargetFileName });
 
     expect(srcSet[0].srcSet).toEqual(['foo-320.jpg']);
     expect(srcSet[1].srcSet).toEqual(['foo-640.jpg', '2x']);
@@ -32,6 +36,9 @@ describe('getSrcSet()', () => {
 });
 
 describe('getSrcSets()', () => {
+  const processTargetFileName = jest.fn();
+  processTargetFileName.mockImplementation(targetFile => targetFile);
+
   jest.spyOn(FileHelpers, 'getFileNameInfo').mockReturnValue(['foo', 'jpg']);
 
   beforeEach(() => {
@@ -41,7 +48,7 @@ describe('getSrcSets()', () => {
   it('should return array of src sets', async () => {
     const widths = [320, 640, 960];
     const srcSets = await Promise.all(
-      getSrcSets({ srcDir, fileName, widths, resolutions })
+      getSrcSets({ srcDir, fileName, widths, resolutions, data, processTargetFileName })
     );
 
     expect(srcSets[0].width).toBe(320);

--- a/examples/remark-html.mjs
+++ b/examples/remark-html.mjs
@@ -21,9 +21,6 @@ const input = `
 ![My GIF image](foo.gif)
 `;
 
-console.log('INPUT', input);
-
 processor.process(input, (_, file) => {
-  console.log('OUTPUT');
   console.log(String(file));
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fec/remark-images",
-  "version": "0.7.2-alpha",
+  "version": "0.7.3-alpha",
   "description": "Remark plugin to generate responsive images.",
   "main": "dist/remark-images.cjs.js",
   "module": "dist/remark-images.esm.js",

--- a/src/DEFAULT_OPTIONS.js
+++ b/src/DEFAULT_OPTIONS.js
@@ -11,6 +11,7 @@ const DEFAULT_OPTIONS = {
   elasticContainer: true,
   blurredBackground: true,
   processCaption: (caption) => caption,
+  processTargetFileName: (targetFile, data) => targetFile,
 };
 
 export default DEFAULT_OPTIONS;

--- a/src/generateImages.js
+++ b/src/generateImages.js
@@ -30,11 +30,13 @@ export async function generateImages({
   srcDir,
   targetDir,
   sourceFile,
+  data,
+  processTargetFileName,
 }) {
   const addDirToFiles = (image) => ({
     width: image.width,
     sourceFile: path.join(srcDir, image.sourceFile),
-    targetFile: path.join(targetDir, image.targetFile),
+    targetFile: processTargetFileName(path.join(targetDir, image.targetFile), data),
   });
 
   const images = [];

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ function findMarkdownImageNodes(markdownAST) {
 }
 
 function responsiveImages(pluginOptions) {
+  const data = this.data();
   const options = { ...DEFAULT_OPTIONS, ...pluginOptions };
 
   options.srcDir = noTrailingSlash(options.srcDir);
@@ -49,13 +50,17 @@ function responsiveImages(pluginOptions) {
               fileName: node.url,
               widths: options.imageSizes,
               resolutions: options.resolutions,
+              data,
+              processTargetFileName: options.processTargetFileName,
             })
           ).then((sources) => {
             generateImages({
+              data,
               srcSets: sources,
               srcDir: options.srcDir,
               sourceFile: node.url,
               targetDir: options.targetDir,
+              processTargetFileName: options.processTargetFileName,
             }).then((generatedImages) => {
               const sourceFile = path.join(options.srcDir, node.url);
               sharp(sourceFile)

--- a/src/srcSetHelpers.js
+++ b/src/srcSetHelpers.js
@@ -10,7 +10,7 @@ export function getHeightFromWidth(width, source) {
   return Math.ceil((width / source.width) * source.height);
 }
 
-export async function getSrcSet({ srcDir, fileName, width, resolutions }) {
+export async function getSrcSet({ srcDir, fileName, width, resolutions, data, processTargetFileName }) {
   const [base, extension] = getFileNameInfo(fileName);
 
   const size = await probeImageSize(
@@ -23,7 +23,7 @@ export async function getSrcSet({ srcDir, fileName, width, resolutions }) {
       const intrinsicHeight = getHeightFromWidth(intrinsicWidth, size);
       const aspectRatio = intrinsicWidth / intrinsicHeight;
       return {
-        src: `${base}-${intrinsicWidth}.${extension}`,
+        src: processTargetFileName(`${base}-${intrinsicWidth}.${extension}`, data),
         intrinsicWidth,
         intrinsicHeight,
         aspectRatio,
@@ -48,7 +48,7 @@ export async function getSrcSet({ srcDir, fileName, width, resolutions }) {
     }));
 }
 
-export function getSrcSets({ srcDir, fileName, widths, resolutions }) {
+export function getSrcSets({ srcDir, fileName, widths, resolutions, data, processTargetFileName }) {
   const sortedResolutions = [...resolutions].sort();
   const sortedWidths = [...widths].sort();
 
@@ -59,6 +59,8 @@ export function getSrcSets({ srcDir, fileName, widths, resolutions }) {
         fileName,
         width,
         resolutions: sortedResolutions,
+        data,
+        processTargetFileName
       }).then((srcSet) => {
         resolve({
           aspectRatio: (srcSet[0] || {}).aspectRatio || 0,


### PR DESCRIPTION
This PR adds an option `processTargetFileName()` which receives as arguments the target file name (as determined by this plugin) and the Remark `data` object. It can returned a transformed target file name. It can be used, for example, to change the target directory based on context data.