### PR TITLE
fix: Fix transforming the target file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ const processor = remark().use([[images, options]]);
 | `elasticContainer`    | `true`                 | Insert elastic container to avoid layout jumps when the image loads                       |
 | `blurredBackground`   | `true`                 | Add a blurred background while the image is loading                                       |
 | `processCaption`      | `(caption) => caption` | Define a function to process image caption, eg. convert markdown to HTML                  |
+| `transformTargetFileName` | `(fileName, data) => fileName` | Define a function to transform the target file name                   |
 
 #### Process Caption
 

--- a/__tests__/generateImages.spec.js
+++ b/__tests__/generateImages.spec.js
@@ -168,32 +168,4 @@ describe('generateImages()', () => {
     expect(toFileMock.mock.calls[1][0]).toBe(`${targetDir}/foo-1280.jpg`);
     expect(toFileMock.mock.calls[2][0]).toBe(`${targetDir}/foo-2880.jpg`);
   });
-
-  it('should use file name returned by processTargetFileName option', async () => {
-    const processTargetFileName = jest.fn();
-    processTargetFileName.mockImplementation(targetFile => targetFile.replace('foo', 'bar'));
-
-    jest.spyOn(FileHelpers, 'isNewerFile').mockReturnValue(true);
-
-    const srcDir = path.dirname(__dirname, 'fixtures');
-    const targetDir = 'test/target';
-    const done = await generateImages({
-      srcSets: srcSetFixture,
-      sourceFile: 'foo.jpg',
-      srcDir,
-      targetDir,
-      processTargetFileName,
-    });
-
-    expect(done).toBe(6);
-
-    expect(resizeMock).toHaveBeenCalledTimes(6);
-    expect(toFileMock).toHaveBeenCalledTimes(6);
-    expect(toFileMock.mock.calls[0][0]).toBe(`${targetDir}/bar-320.jpg`);
-    expect(toFileMock.mock.calls[1][0]).toBe(`${targetDir}/bar-640.jpg`);
-    expect(toFileMock.mock.calls[2][0]).toBe(`${targetDir}/bar-960.jpg`);
-    expect(toFileMock.mock.calls[3][0]).toBe(`${targetDir}/bar-1280.jpg`);
-    expect(toFileMock.mock.calls[4][0]).toBe(`${targetDir}/bar-1920.jpg`);
-    expect(toFileMock.mock.calls[5][0]).toBe(`${targetDir}/bar-2880.jpg`);
-  });
 });

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -86,12 +86,12 @@ describe('remark-images', () => {
     expect(result('img').attr('alt')).toBe('My image');
   });
 
-  it('should use result processTargetFileName() option for file name', async () => {
-    const processTargetFileName = (targetFile, data) =>
+  it('should use result transformTargetFileName() option for file name', async () => {
+    const transformTargetFileName = (targetFile, data) =>
       targetFile.replace(data.search, data.replace);
     const thisProcessor = remark()
       .use(html, { sanitize: false })
-      .use([[plugin, { ...options, processTargetFileName }]]);
+      .use([[plugin, { ...options, transformTargetFileName }]]);
 
     const input = '![My image](foo.jpg)';
 

--- a/__tests__/srcSetHelpers.spec.js
+++ b/__tests__/srcSetHelpers.spec.js
@@ -14,8 +14,8 @@ const resolutions = [1, 2];
 const data = {};
 
 describe('getSrcSet()', () => {
-  const processTargetFileName = jest.fn();
-  processTargetFileName.mockImplementation(targetFile => targetFile);
+  const transformTargetFileName = jest.fn();
+  transformTargetFileName.mockImplementation(targetFile => targetFile);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,7 +28,7 @@ describe('getSrcSet()', () => {
   });
 
   it('should return src set for multiple resolutions', async () => {
-    const srcSet = await getSrcSet({ srcDir, fileName, width, resolutions, data, processTargetFileName });
+    const srcSet = await getSrcSet({ srcDir, fileName, width, resolutions, data, transformTargetFileName });
 
     expect(srcSet[0].srcSet).toEqual(['foo-320.jpg']);
     expect(srcSet[1].srcSet).toEqual(['foo-640.jpg', '2x']);
@@ -36,8 +36,8 @@ describe('getSrcSet()', () => {
 });
 
 describe('getSrcSets()', () => {
-  const processTargetFileName = jest.fn();
-  processTargetFileName.mockImplementation(targetFile => targetFile);
+  const transformTargetFileName = jest.fn();
+  transformTargetFileName.mockImplementation(targetFile => targetFile);
 
   jest.spyOn(FileHelpers, 'getFileNameInfo').mockReturnValue(['foo', 'jpg']);
 
@@ -48,7 +48,7 @@ describe('getSrcSets()', () => {
   it('should return array of src sets', async () => {
     const widths = [320, 640, 960];
     const srcSets = await Promise.all(
-      getSrcSets({ srcDir, fileName, widths, resolutions, data, processTargetFileName })
+      getSrcSets({ srcDir, fileName, widths, resolutions, data, transformTargetFileName })
     );
 
     expect(srcSets[0].width).toBe(320);

--- a/src/DEFAULT_OPTIONS.js
+++ b/src/DEFAULT_OPTIONS.js
@@ -11,7 +11,7 @@ const DEFAULT_OPTIONS = {
   elasticContainer: true,
   blurredBackground: true,
   processCaption: (caption) => caption,
-  processTargetFileName: (targetFile, data) => targetFile,
+  transformTargetFileName: (targetFile, data) => targetFile,
 };
 
 export default DEFAULT_OPTIONS;

--- a/src/generateImages.js
+++ b/src/generateImages.js
@@ -30,13 +30,11 @@ export async function generateImages({
   srcDir,
   targetDir,
   sourceFile,
-  data,
-  processTargetFileName,
 }) {
   const addDirToFiles = (image) => ({
     width: image.width,
     sourceFile: path.join(srcDir, image.sourceFile),
-    targetFile: processTargetFileName(path.join(targetDir, image.targetFile), data),
+    targetFile: path.join(targetDir, image.targetFile),
   });
 
   const images = [];

--- a/src/index.js
+++ b/src/index.js
@@ -51,16 +51,14 @@ function responsiveImages(pluginOptions) {
               widths: options.imageSizes,
               resolutions: options.resolutions,
               data,
-              processTargetFileName: options.processTargetFileName,
+              transformTargetFileName: options.transformTargetFileName,
             })
           ).then((sources) => {
             generateImages({
-              data,
               srcSets: sources,
               srcDir: options.srcDir,
               sourceFile: node.url,
               targetDir: options.targetDir,
-              processTargetFileName: options.processTargetFileName,
             }).then((generatedImages) => {
               const sourceFile = path.join(options.srcDir, node.url);
               sharp(sourceFile)

--- a/src/srcSetHelpers.js
+++ b/src/srcSetHelpers.js
@@ -10,7 +10,7 @@ export function getHeightFromWidth(width, source) {
   return Math.ceil((width / source.width) * source.height);
 }
 
-export async function getSrcSet({ srcDir, fileName, width, resolutions, data, processTargetFileName }) {
+export async function getSrcSet({ srcDir, fileName, width, resolutions, data, transformTargetFileName }) {
   const [base, extension] = getFileNameInfo(fileName);
 
   const size = await probeImageSize(
@@ -23,7 +23,7 @@ export async function getSrcSet({ srcDir, fileName, width, resolutions, data, pr
       const intrinsicHeight = getHeightFromWidth(intrinsicWidth, size);
       const aspectRatio = intrinsicWidth / intrinsicHeight;
       return {
-        src: processTargetFileName(`${base}-${intrinsicWidth}.${extension}`, data),
+        src: transformTargetFileName(`${base}-${intrinsicWidth}.${extension}`, data),
         intrinsicWidth,
         intrinsicHeight,
         aspectRatio,
@@ -48,7 +48,7 @@ export async function getSrcSet({ srcDir, fileName, width, resolutions, data, pr
     }));
 }
 
-export function getSrcSets({ srcDir, fileName, widths, resolutions, data, processTargetFileName }) {
+export function getSrcSets({ srcDir, fileName, widths, resolutions, data, transformTargetFileName }) {
   const sortedResolutions = [...resolutions].sort();
   const sortedWidths = [...widths].sort();
 
@@ -60,7 +60,7 @@ export function getSrcSets({ srcDir, fileName, widths, resolutions, data, proces
         width,
         resolutions: sortedResolutions,
         data,
-        processTargetFileName
+        transformTargetFileName
       }).then((srcSet) => {
         resolve({
           aspectRatio: (srcSet[0] || {}).aspectRatio || 0,


### PR DESCRIPTION
The target file name is only transformed (previously processed) when generating the srcSets; removed the additional processing when generating the image file, since they were duplicates.