### PR TITLE
feat: Add manifest option to allow caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ const processor = remark().use([[images, options]]);
 | `blurredBackground`       | `true`                         | Add a blurred background while the image is loading                                       |
 | `processCaption`          | `(caption) => caption`         | Define a function to process image caption, eg. convert markdown to HTML                  |
 | `transformTargetFileName` | `(fileName, data) => fileName` | Define a function to transform the target file name                                       |
+| `manifest`                | `false`                        | Path to the manifest file used to skip regenerating unchanged images across builds. Disabled by default; set to a file path (e.g. `"remark-images-manifest.json"`) to enable. |
+
+#### Manifest-based image cache
+
+The plugin writes a JSON manifest file after generating images. On the next build, if the source image hash and all generated files on disk match the manifest entry, sharp processing is skipped entirely for that image. This allows CI pipelines to cache the `targetDir` between runs and avoid regenerating unchanged images.
+
+Set `manifest: false` to disable this behaviour entirely.
 
 #### Process Caption
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const processor = remark().use([[images, options]]);
 
 #### Manifest-based image cache
 
-The plugin writes a JSON manifest file after generating images. On the next build, if the source image hash and all generated files on disk match the manifest entry, sharp processing is skipped entirely for that image. This allows CI pipelines to cache the `targetDir` between runs and avoid regenerating unchanged images.
+The plugin writes a JSON manifest file after generating images. On the next build, if the source image hash and all generated files on disk match the manifest entry, processing is skipped entirely for that image. This allows CI pipelines to cache the `targetDir` between runs and avoid regenerating unchanged images.
 
 Set `manifest: false` to disable this behaviour entirely.
 

--- a/__tests__/generateImages.spec.js
+++ b/__tests__/generateImages.spec.js
@@ -50,7 +50,7 @@ describe('generateImage()', () => {
       size: 17986,
     });
 
-    const sourceFile = path.dirname(__dirname, 'fixtures', 'foo.jpg');
+    const sourceFile = path.join(__dirname, 'fixtures', 'foo.jpg');
     const targetFile = './test-florian.jpg';
     const width = 320;
     const height = 214;
@@ -77,7 +77,7 @@ describe('generateImage()', () => {
       size: 17986,
     });
 
-    const sourceFile = path.dirname(__dirname, 'fixtures', 'foo.jpg');
+    const sourceFile = path.join(__dirname, 'fixtures', 'foo.jpg');
     const targetFile = './test-florian.jpg';
     const width = 320;
     const height = 214;
@@ -112,7 +112,7 @@ describe('generateImages()', () => {
     const processTargetFileName = jest.fn();
     processTargetFileName.mockImplementation(targetFile => targetFile);
 
-    const srcDir = path.dirname(__dirname, 'fixtures');
+    const srcDir = path.join(__dirname, 'fixtures');
     const targetDir = 'test/target';
     const done = await generateImages({
       srcSets: srcSetFixture,
@@ -153,7 +153,7 @@ describe('generateImages()', () => {
     isNewerFileMock.mockReturnValueOnce(false);
     isNewerFileMock.mockReturnValueOnce(true);
 
-    const srcDir = path.dirname(__dirname, 'fixtures');
+    const srcDir = path.join(__dirname, 'fixtures');
     const targetDir = 'test/target';
     const done = await generateImages({
       srcSets: srcSetFixture,
@@ -180,7 +180,7 @@ describe('generateImages() with manifest', () => {
   const sharpReturn = { resize: resizeMock, toFile: toFileMock };
   const hashFileMock = jest.spyOn(ManifestHelpers, 'hashFile');
 
-  const srcDir = path.dirname(__dirname, 'fixtures');
+  const srcDir = path.join(__dirname, 'fixtures');
   const targetDir = 'test/target';
 
   beforeEach(() => {
@@ -267,6 +267,62 @@ describe('generateImages() with manifest', () => {
         'foo.jpg': {
           sourceHash: 'different-hash',
           files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+        },
+      },
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done.count).toBe(6);
+    expect(done.manifestEntry).toEqual({
+      sourceHash: 'abc123',
+      files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+    });
+  });
+
+  it('cache miss – recorded files are a subset of expected files (options changed) → regenerates', async () => {
+    jest.spyOn(FileHelpers, 'fileExists').mockReturnValue(true);
+
+    const manifest = {
+      version: 1,
+      images: {
+        'foo.jpg': {
+          sourceHash: 'abc123',
+          files: ['foo-320.jpg', 'foo-640.jpg'],
+        },
+      },
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done.count).toBe(6);
+    expect(done.manifestEntry).toEqual({
+      sourceHash: 'abc123',
+      files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+    });
+  });
+
+  it('cache miss – entry.files is not an array → regenerates without throwing', async () => {
+    jest.spyOn(FileHelpers, 'fileExists').mockReturnValue(true);
+
+    const manifest = {
+      version: 1,
+      images: {
+        'foo.jpg': {
+          sourceHash: 'abc123',
+          files: 'foo-320.jpg',
         },
       },
     };

--- a/__tests__/generateImages.spec.js
+++ b/__tests__/generateImages.spec.js
@@ -6,6 +6,7 @@ import {
   generateImages,
 } from '../src/generateImages';
 import * as FileHelpers from '../src/fileHelpers';
+import * as ManifestHelpers from '../src/manifest';
 import srcSetFixture from './fixtures/srcSetFixture';
 import path from 'path';
 import * as fs from 'fs';
@@ -14,6 +15,7 @@ jest.mock('sharp');
 jest.mock('probe-image-size');
 jest.mock('../src/fileHelpers');
 jest.mock('fs');
+jest.mock('../src/manifest');
 
 describe('getHeightFromWidth()', () => {
   it('should return height for given width and source image', () => {
@@ -120,7 +122,7 @@ describe('generateImages()', () => {
       processTargetFileName,
     });
 
-    expect(done).toBe(6);
+    expect(done.count).toBe(6);
 
     expect(resizeMock).toHaveBeenCalledTimes(6);
     expect(resizeMock.mock.calls[0][0]).toEqual({ width: 320, height: 214 });
@@ -161,11 +163,155 @@ describe('generateImages()', () => {
       processTargetFileName,
     });
 
-    expect(done).toBe(3);
+    expect(done.count).toBe(3);
 
     expect(toFileMock).toHaveBeenCalledTimes(3);
     expect(toFileMock.mock.calls[0][0]).toBe(`${targetDir}/foo-320.jpg`);
     expect(toFileMock.mock.calls[1][0]).toBe(`${targetDir}/foo-1280.jpg`);
     expect(toFileMock.mock.calls[2][0]).toBe(`${targetDir}/foo-2880.jpg`);
+  });
+});
+
+describe('generateImages() with manifest', () => {
+  const probeImageSizeMock = jest.spyOn(ProbeImageSize, 'default');
+  const sharpMock = jest.spyOn(Sharp, 'default');
+  const resizeMock = jest.fn();
+  const toFileMock = jest.fn();
+  const sharpReturn = { resize: resizeMock, toFile: toFileMock };
+  const hashFileMock = jest.spyOn(ManifestHelpers, 'hashFile');
+
+  const srcDir = path.dirname(__dirname, 'fixtures');
+  const targetDir = 'test/target';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(fs, 'createReadStream');
+    jest.spyOn(FileHelpers, 'isNewerFile').mockReturnValue(true);
+
+    sharpMock.mockReturnValue(sharpReturn);
+    resizeMock.mockReturnValue(sharpReturn);
+    toFileMock.mockResolvedValue({ size: 17986 });
+
+    probeImageSizeMock.mockResolvedValue({ width: 6000, height: 4000 });
+    hashFileMock.mockReturnValue('abc123');
+  });
+
+  it('no manifest → manifestEntry is null, count matches generated files', async () => {
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+    });
+
+    expect(done.manifestEntry).toBeNull();
+    expect(done.count).toBe(6);
+  });
+
+  it('cache hit (hash matches, all files exist) → returns { count: 0, manifestEntry: null }, no sharp calls', async () => {
+    const existsMock = jest.spyOn(FileHelpers, 'fileExists').mockReturnValue(true);
+
+    const manifest = {
+      version: 1,
+      images: {
+        'foo.jpg': {
+          sourceHash: 'abc123',
+          files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+        },
+      },
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done).toEqual({ count: 0, manifestEntry: null });
+    expect(toFileMock).not.toHaveBeenCalled();
+    expect(existsMock).toHaveBeenCalled();
+  });
+
+  it('cache miss – no entry for this file → generates and returns manifestEntry', async () => {
+    jest.spyOn(FileHelpers, 'fileExists').mockReturnValue(true);
+
+    const manifest = {
+      version: 1,
+      images: {},
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done.count).toBe(6);
+    expect(done.manifestEntry).toEqual({
+      sourceHash: 'abc123',
+      files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+    });
+  });
+
+  it('cache miss – hash mismatch → generates and returns manifestEntry', async () => {
+    jest.spyOn(FileHelpers, 'fileExists').mockReturnValue(true);
+
+    const manifest = {
+      version: 1,
+      images: {
+        'foo.jpg': {
+          sourceHash: 'different-hash',
+          files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+        },
+      },
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done.count).toBe(6);
+    expect(done.manifestEntry).toEqual({
+      sourceHash: 'abc123',
+      files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+    });
+  });
+
+  it('cache miss – files missing → generates and returns manifestEntry', async () => {
+    jest.spyOn(FileHelpers, 'fileExists')
+      .mockReturnValueOnce(false);
+
+    const manifest = {
+      version: 1,
+      images: {
+        'foo.jpg': {
+          sourceHash: 'abc123',
+          files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+        },
+      },
+    };
+
+    const done = await generateImages({
+      srcSets: srcSetFixture,
+      sourceFile: 'foo.jpg',
+      srcDir,
+      targetDir,
+      manifest,
+    });
+
+    expect(done.count).toBe(6);
+    expect(done.manifestEntry).toEqual({
+      sourceHash: 'abc123',
+      files: ['foo-320.jpg', 'foo-640.jpg', 'foo-960.jpg', 'foo-1280.jpg', 'foo-1920.jpg', 'foo-2880.jpg'],
+    });
   });
 });

--- a/__tests__/integration.spec.js
+++ b/__tests__/integration.spec.js
@@ -224,6 +224,60 @@ describe('remark-images integration', () => {
     });
   });
 
+  describe('manifest', () => {
+    const manifestPath = path.join(__dirname, 'fixtures-target-integration', 'test-manifest.json');
+
+    it('manifest is created after processing', async () => {
+      await makeProcessor({ manifest: manifestPath }).process('![Alt](foo.jpg)');
+
+      expect(fs.existsSync(manifestPath)).toBe(true);
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      expect(manifest.images['foo.jpg']).toBeDefined();
+      expect(typeof manifest.images['foo.jpg'].sourceHash).toBe('string');
+      expect(Array.isArray(manifest.images['foo.jpg'].files)).toBe(true);
+      expect(manifest.images['foo.jpg'].files.length).toBeGreaterThan(0);
+    });
+
+    it('cache hit skips image regeneration', async () => {
+      // First run: generate files and write manifest
+      await makeProcessor({ manifest: manifestPath }).process('![Alt](foo.jpg)');
+      expect(fs.existsSync(manifestPath)).toBe(true);
+
+      // Second run: files exist + manifest matches → cache hit, no regeneration
+      // The manifest should still exist and have the same content
+      const manifestBefore = fs.readFileSync(manifestPath, 'utf8');
+      await makeProcessor({ manifest: manifestPath }).process('![Alt](foo.jpg)');
+      const manifestAfter = fs.readFileSync(manifestPath, 'utf8');
+
+      // manifest content unchanged because no manifestUpdates were written (cache hit)
+      expect(manifestAfter).toBe(manifestBefore);
+    });
+
+    it('manifest: false disables the manifest', async () => {
+      const defaultManifestPath = path.resolve('remark-images-manifest.json');
+      const cleanupDefault = () => {
+        if (fs.existsSync(defaultManifestPath)) fs.unlinkSync(defaultManifestPath);
+      };
+      cleanupDefault();
+
+      await makeProcessor({ manifest: false }).process('![Alt](foo.jpg)');
+
+      expect(fs.existsSync(manifestPath)).toBe(false);
+      expect(fs.existsSync(defaultManifestPath)).toBe(false);
+      cleanupDefault();
+    });
+
+    it('custom manifest path creates the file at that path', async () => {
+      const customManifest = path.join(__dirname, 'fixtures-target-integration', 'custom-manifest.json');
+      await makeProcessor({ manifest: customManifest }).process('![Alt](foo.jpg)');
+
+      expect(fs.existsSync(customManifest)).toBe(true);
+      const manifest = JSON.parse(fs.readFileSync(customManifest, 'utf8'));
+      expect(manifest.version).toBe(1);
+      expect(manifest.images['foo.jpg']).toBeDefined();
+    });
+  });
+
   describe('PNG image support', () => {
     const pngFixture = path.join(fixturesDir, 'test-integration.png');
 

--- a/__tests__/manifest.spec.js
+++ b/__tests__/manifest.spec.js
@@ -66,6 +66,22 @@ describe('readManifest()', () => {
     const result = readManifest('/manifest.json');
     expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
   });
+
+  it('file exists, valid version but missing images → returns empty manifest', () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify({ version: MANIFEST_VERSION }));
+    const result = readManifest('/manifest.json');
+    expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
+  });
+
+  it('file exists, valid version but images is not a plain object → returns empty manifest', () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(
+      JSON.stringify({ version: MANIFEST_VERSION, images: ['foo.jpg'] })
+    );
+    const result = readManifest('/manifest.json');
+    expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
+  });
 });
 
 describe('writeManifest()', () => {

--- a/__tests__/manifest.spec.js
+++ b/__tests__/manifest.spec.js
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import { MANIFEST_VERSION, hashFile, readManifest, writeManifest } from '../src/manifest';
+
+jest.mock('fs');
+
+describe('hashFile()', () => {
+  it('returns a 64-char hex string (SHA-256)', () => {
+    fs.readFileSync.mockReturnValue(Buffer.from('hello world'));
+    const hash = hashFile('/some/file.jpg');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('same content → same hash', () => {
+    const content = Buffer.from('same content');
+    fs.readFileSync.mockReturnValue(content);
+    const hash1 = hashFile('/file1.jpg');
+    fs.readFileSync.mockReturnValue(content);
+    const hash2 = hashFile('/file2.jpg');
+    expect(hash1).toBe(hash2);
+  });
+
+  it('different content → different hash', () => {
+    fs.readFileSync.mockReturnValue(Buffer.from('content A'));
+    const hash1 = hashFile('/file1.jpg');
+    fs.readFileSync.mockReturnValue(Buffer.from('content B'));
+    const hash2 = hashFile('/file2.jpg');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('readManifest()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('file does not exist → returns empty manifest', () => {
+    fs.existsSync.mockReturnValue(false);
+    const result = readManifest('/nonexistent.json');
+    expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
+  });
+
+  it('file exists, valid version → returns parsed manifest', () => {
+    const manifest = {
+      version: MANIFEST_VERSION,
+      images: {
+        'foo.jpg': { sourceHash: 'abc123', files: ['foo-320.jpg'] },
+      },
+    };
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify(manifest));
+    const result = readManifest('/manifest.json');
+    expect(result).toEqual(manifest);
+  });
+
+  it('file exists, wrong version → returns empty manifest', () => {
+    const manifest = { version: 99, images: { 'foo.jpg': {} } };
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify(manifest));
+    const result = readManifest('/manifest.json');
+    expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
+  });
+
+  it('file exists, invalid JSON → returns empty manifest', () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue('not valid json {{{{');
+    const result = readManifest('/manifest.json');
+    expect(result).toEqual({ version: MANIFEST_VERSION, images: {} });
+  });
+});
+
+describe('writeManifest()', () => {
+  it('calls fs.writeFileSync with the correct arguments', () => {
+    const manifest = {
+      version: MANIFEST_VERSION,
+      images: { 'foo.jpg': { sourceHash: 'abc123', files: ['foo-320.jpg'] } },
+    };
+    writeManifest('/output.json', manifest);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/output.json',
+      JSON.stringify(manifest, null, 2) + '\n',
+      'utf8'
+    );
+  });
+});

--- a/src/DEFAULT_OPTIONS.js
+++ b/src/DEFAULT_OPTIONS.js
@@ -12,6 +12,7 @@ const DEFAULT_OPTIONS = {
   blurredBackground: true,
   processCaption: (caption) => caption,
   transformTargetFileName: (targetFile, data) => targetFile,
+  manifest: false,
 };
 
 export default DEFAULT_OPTIONS;

--- a/src/generateImages.js
+++ b/src/generateImages.js
@@ -54,12 +54,16 @@ export async function generateImages({
 
   const sourceHash = manifest ? hashFile(path.join(srcDir, sourceFile)) : null;
 
+  const expectedFiles = images.map((i) => i.targetFile);
+
   if (manifest) {
     const entry = manifest.images?.[sourceFile];
     if (
       entry &&
       entry.sourceHash === sourceHash &&
-      entry.files.every((f) => fileExists(path.join(targetDir, f)))
+      Array.isArray(entry.files) &&
+      expectedFiles.every((f) => entry.files.includes(f)) &&
+      expectedFiles.every((f) => fileExists(path.join(targetDir, f)))
     ) {
       debug('Cache hit for "%s", skipping generation', sourceFile);
       return { count: 0, manifestEntry: null };
@@ -92,8 +96,6 @@ export async function generateImages({
   const results = await Promise.all(queue);
   return {
     count: results.filter((r) => r).length,
-    manifestEntry: manifest
-      ? { sourceHash, files: images.map((i) => i.targetFile) }
-      : null,
+    manifestEntry: manifest ? { sourceHash, files: expectedFiles } : null,
   };
 }

--- a/src/generateImages.js
+++ b/src/generateImages.js
@@ -4,6 +4,7 @@ import path from 'path';
 import probeImageSize from 'probe-image-size';
 import sharp from 'sharp';
 import { fileExists, isNewerFile } from './fileHelpers.js';
+import { hashFile } from './manifest.js';
 
 const debug = createDebug('RemarkResponsiveImages');
 
@@ -30,6 +31,7 @@ export async function generateImages({
   srcDir,
   targetDir,
   sourceFile,
+  manifest = null,
 }) {
   const addDirToFiles = (image) => ({
     width: image.width,
@@ -49,6 +51,20 @@ export async function generateImages({
       }
     });
   });
+
+  const sourceHash = manifest ? hashFile(path.join(srcDir, sourceFile)) : null;
+
+  if (manifest) {
+    const entry = manifest.images?.[sourceFile];
+    if (
+      entry &&
+      entry.sourceHash === sourceHash &&
+      entry.files.every((f) => fileExists(path.join(targetDir, f)))
+    ) {
+      debug('Cache hit for "%s", skipping generation', sourceFile);
+      return { count: 0, manifestEntry: null };
+    }
+  }
 
   const queue = images
     .map(addDirToFiles)
@@ -74,5 +90,10 @@ export async function generateImages({
     );
 
   const results = await Promise.all(queue);
-  return results.filter((r) => r).length;
+  return {
+    count: results.filter((r) => r).length,
+    manifestEntry: manifest
+      ? { sourceHash, files: images.map((i) => i.targetFile) }
+      : null,
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { visitParents } from 'unist-util-visit-parents';
 import DEFAULT_OPTIONS from './DEFAULT_OPTIONS.js';
 import { fileExists, noTrailingSlash } from './fileHelpers.js';
 import { generateImages } from './generateImages.js';
+import { readManifest, writeManifest } from './manifest.js';
 import { findParentLinks } from './remarkHelpers.js';
 import { renderFigure } from './render.js';
 import { getSrcSets } from './srcSetHelpers.js';
@@ -40,6 +41,11 @@ function responsiveImages(pluginOptions) {
 
     debug('Found %d nodes to process', markdownImageNodes.length);
 
+    const manifestData = options.manifest
+      ? readManifest(path.resolve(options.manifest))
+      : null;
+    const manifestUpdates = {};
+
     const promises = markdownImageNodes
       .filter(({ node }) => fileExists(path.join(options.srcDir, node.url)))
       .map(({ node, inLink }) => {
@@ -59,7 +65,11 @@ function responsiveImages(pluginOptions) {
               srcDir: options.srcDir,
               sourceFile: node.url,
               targetDir: options.targetDir,
-            }).then((generatedImages) => {
+              manifest: manifestData,
+            }).then(({ count, manifestEntry }) => {
+              if (manifestEntry) {
+                manifestUpdates[node.url] = manifestEntry;
+              }
               const sourceFile = path.join(options.srcDir, node.url);
               sharp(sourceFile)
                 .resize(20, 20)
@@ -68,7 +78,7 @@ function responsiveImages(pluginOptions) {
                 .then(([bgImage, bgData]) => {
                   debug(
                     'Generated %d images for node %O',
-                    generatedImages,
+                    count,
                     node
                   );
                   resolve({ node, sources, inLink, bgImage, bgData });
@@ -95,6 +105,13 @@ function responsiveImages(pluginOptions) {
           hChildren: figure.children,
         };
       });
+
+      if (manifestData && Object.keys(manifestUpdates).length > 0) {
+        writeManifest(path.resolve(options.manifest), {
+          ...manifestData,
+          images: { ...manifestData.images, ...manifestUpdates },
+        });
+      }
     });
   }
 

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,0 +1,26 @@
+import { createHash } from 'crypto';
+import fs from 'fs';
+
+export const MANIFEST_VERSION = 1;
+
+export function hashFile(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+export function readManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) {
+    return { version: MANIFEST_VERSION, images: {} };
+  }
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return raw.version === MANIFEST_VERSION
+      ? raw
+      : { version: MANIFEST_VERSION, images: {} };
+  } catch {
+    return { version: MANIFEST_VERSION, images: {} };
+  }
+}
+
+export function writeManifest(manifestPath, manifest) {
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+}

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -13,9 +13,15 @@ export function readManifest(manifestPath) {
   }
   try {
     const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    return raw.version === MANIFEST_VERSION
-      ? raw
-      : { version: MANIFEST_VERSION, images: {} };
+    if (
+      raw.version === MANIFEST_VERSION &&
+      raw.images &&
+      typeof raw.images === 'object' &&
+      !Array.isArray(raw.images)
+    ) {
+      return raw;
+    }
+    return { version: MANIFEST_VERSION, images: {} };
   } catch {
     return { version: MANIFEST_VERSION, images: {} };
   }


### PR DESCRIPTION
## Add manifest-based image caching

Adds an opt-in cache so unchanged images aren't reprocessed by sharp on every build. CI pipelines can persist targetDir and the manifest file between runs to skip regenerating images whose sources haven't changed.

## What's new

- New manifest option (default false). Set it to a file path (e.g. "remark-images-manifest.json") to enable caching.
- The plugin writes a versioned JSON manifest after generating images, recording each source image's content hash and its generated output files.
- On the next build, if the source hash and all expected output files match the manifest entry, sharp processing is skipped entirely for that image.

## How it works

- readManifest() loads the manifest, falling back to an empty one if the file is missing, unparseable, the wrong version, or malformed.
- For each image, the source is hashed (SHA-256) and compared against its manifest entry:
  - Cache hit (hash matches + all currently-expected files present on disk) → skip generation.
  - Cache miss → generate images and record an updated entry.
- The merged manifest is written back to disk after all images are processed.
